### PR TITLE
Fixed gui blend bug

### DIFF
--- a/lowrez/render/lowrez.render_script
+++ b/lowrez/render/lowrez.render_script
@@ -133,7 +133,6 @@ local function draw_upscaled(self)
 	local offsety = (window_height - height) / 2
 
 	-- draw!
-	render.disable_state(render.STATE_BLEND)
 	render.set_viewport(offsetx, offsety, width, height)
 	render.set_view(IDENTITY)
 	render.set_projection(IDENTITY)
@@ -159,6 +158,7 @@ local function draw_controls(self)
 	render.draw(self.controls_pred)
 	--render.draw(self.text_pred)
 	render.disable_state(render.STATE_STENCIL_TEST)
+	render.disable_state(render.STATE_BLEND)
 end
 
 function update(self)


### PR DESCRIPTION
Disabling **STATE_BLEND** was moved from _draw_upscaled(self)_ to _draw_controls(self)_

### Example from examples/lowrezjam:

Before:

![Снимок экрана от 2024-12-01 02-25-10](https://github.com/user-attachments/assets/5ce3d647-8588-426e-af0f-4b5da3c62280)

After:

![Снимок экрана от 2024-12-01 02-26-16](https://github.com/user-attachments/assets/4e9379e5-087c-4853-a6ec-14cbcf294ff6)

### Example from my project (virtual analog):

Before:

![Снимок экрана от 2024-12-01 02-38-33](https://github.com/user-attachments/assets/ba276cc9-4836-4825-afbc-26ba4dce4222)

After:

![Снимок экрана от 2024-12-01 02-39-39](https://github.com/user-attachments/assets/05738b1f-552e-439d-8b68-b9a34ae4de0f)
