### PR TITLE
Fix snap parameter name in handling set_scale_snap message

### DIFF
--- a/lowrez/render/lowrez.render_script
+++ b/lowrez/render/lowrez.render_script
@@ -188,7 +188,7 @@ function on_message(self, message_id, message)
 		end
 		coords.scale_snap = self.scale_snap
 	elseif message_id == SET_SCALE_SNAP then
-		self.scale_snap = message.scale_snap
+		self.scale_snap = message.snap
 		coords.scale_snap = message.snap
 	elseif message_id == SET_SIZE then
 		setup(self, message.width, message.height)


### PR DESCRIPTION
The provided game objects send a single `snap` parameter in the message, but the message handling is using both `scale_snap` and `snap` which causes a mismatch. This fixes it.