### PR TITLE
Shader and render_script update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ Thumbs.db
 .project
 .cproject
 builtins
+/.editor_settings
+build_config.json
+.clang-format
+compile_commands.json
+manifest.private.der
+manifest.public.der

--- a/examples/lowrezjam/lowrezjam.collection
+++ b/examples/lowrezjam/lowrezjam.collection
@@ -2,22 +2,6 @@ name: "lowrezjam"
 instances {
   id: "lowrezjam"
   prototype: "/lowrez/lowrezjam.go"
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale3 {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-  }
 }
 scale_along_z: 0
 embedded_instances {
@@ -25,37 +9,8 @@ embedded_instances {
   data: "components {\n"
   "  id: \"hud\"\n"
   "  component: \"/examples/lowrezjam/hud.gui\"\n"
-  "  position {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "  }\n"
-  "  rotation {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "    w: 1.0\n"
-  "  }\n"
-  "  property_decls {\n"
-  "  }\n"
   "}\n"
   ""
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale3 {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-  }
 }
 embedded_instances {
   id: "game"
@@ -64,37 +19,8 @@ embedded_instances {
   data: "components {\n"
   "  id: \"game\"\n"
   "  component: \"/examples/lowrezjam/lowrezjam.script\"\n"
-  "  position {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "  }\n"
-  "  rotation {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "    w: 1.0\n"
-  "  }\n"
-  "  property_decls {\n"
-  "  }\n"
   "}\n"
   ""
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale3 {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-  }
 }
 embedded_instances {
   id: "title"
@@ -104,32 +30,9 @@ embedded_instances {
   "  data: \"size {\\n"
   "  x: 128.0\\n"
   "  y: 32.0\\n"
-  "  z: 0.0\\n"
-  "  w: 0.0\\n"
-  "}\\n"
-  "color {\\n"
-  "  x: 1.0\\n"
-  "  y: 1.0\\n"
-  "  z: 1.0\\n"
-  "  w: 1.0\\n"
-  "}\\n"
-  "outline {\\n"
-  "  x: 0.0\\n"
-  "  y: 0.0\\n"
-  "  z: 0.0\\n"
-  "  w: 1.0\\n"
-  "}\\n"
-  "shadow {\\n"
-  "  x: 0.0\\n"
-  "  y: 0.0\\n"
-  "  z: 0.0\\n"
-  "  w: 1.0\\n"
   "}\\n"
   "leading: 0.0\\n"
-  "tracking: 0.0\\n"
-  "pivot: PIVOT_CENTER\\n"
-  "blend_mode: BLEND_MODE_ALPHA\\n"
-  "line_break: false\\n"
+  "tracking: 0.01\\n"
   "text: \\\"LOWREZJAM\\\"\\n"
   "font: \\\"/lowrez/fonts/pixelfont.font\\\"\\n"
   "material: \\\"/builtins/fonts/label.material\\\"\\n"
@@ -137,68 +40,20 @@ embedded_instances {
   "  position {\n"
   "    x: 32.0\n"
   "    y: 11.0\n"
-  "    z: 0.0\n"
-  "  }\n"
-  "  rotation {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "    w: 1.0\n"
   "  }\n"
   "}\n"
   ""
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale3 {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-  }
 }
 embedded_instances {
   id: "stars"
   data: "components {\n"
   "  id: \"stars\"\n"
   "  component: \"/examples/lowrezjam/assets/particlefx/stars.particlefx\"\n"
-  "  position {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "  }\n"
-  "  rotation {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "    w: 1.0\n"
-  "  }\n"
-  "  property_decls {\n"
-  "  }\n"
   "}\n"
   ""
   position {
     x: 32.0
     y: 64.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale3 {
-    x: 1.0
-    y: 1.0
-    z: 1.0
   }
 }
 embedded_instances {
@@ -206,37 +61,8 @@ embedded_instances {
   data: "components {\n"
   "  id: \"controls\"\n"
   "  component: \"/examples/lowrezjam/controls.gui\"\n"
-  "  position {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "  }\n"
-  "  rotation {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "    w: 1.0\n"
-  "  }\n"
-  "  property_decls {\n"
-  "  }\n"
   "}\n"
   ""
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale3 {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-  }
 }
 embedded_instances {
   id: "camera"
@@ -247,77 +73,51 @@ embedded_instances {
   "fov: 0.7854\\n"
   "near_z: -1.0\\n"
   "far_z: 1.0\\n"
-  "auto_aspect_ratio: 0\\n"
-  "orthographic_projection: 0\\n"
-  "orthographic_zoom: 1.0\\n"
   "\"\n"
-  "  position {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "  }\n"
-  "  rotation {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "    w: 1.0\n"
-  "  }\n"
   "}\n"
   ""
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale3 {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-  }
 }
 embedded_instances {
   id: "logo"
   data: "embedded_components {\n"
   "  id: \"sprite\"\n"
   "  type: \"sprite\"\n"
-  "  data: \"tile_set: \\\"/examples/lowrezjam/assets/atlases/game.atlas\\\"\\n"
-  "default_animation: \\\"logo\\\"\\n"
+  "  data: \"default_animation: \\\"logo\\\"\\n"
   "material: \\\"/builtins/materials/sprite.material\\\"\\n"
-  "blend_mode: BLEND_MODE_ALPHA\\n"
+  "textures {\\n"
+  "  sampler: \\\"texture_sampler\\\"\\n"
+  "  texture: \\\"/examples/lowrezjam/assets/atlases/game.atlas\\\"\\n"
+  "}\\n"
   "\"\n"
-  "  position {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "  }\n"
-  "  rotation {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "    w: 1.0\n"
-  "  }\n"
   "}\n"
   ""
   position {
     x: 32.0
     y: 32.5
-    z: 0.0
   }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale3 {
-    x: 1.0
-    y: 1.0
-    z: 1.0
+}
+embedded_instances {
+  id: "scale"
+  data: "embedded_components {\n"
+  "  id: \"label\"\n"
+  "  type: \"label\"\n"
+  "  data: \"size {\\n"
+  "  x: 128.0\\n"
+  "  y: 32.0\\n"
+  "}\\n"
+  "leading: 0.0\\n"
+  "tracking: 0.01\\n"
+  "text: \\\"0\\\"\\n"
+  "font: \\\"/lowrez/fonts/pixelfont.font\\\"\\n"
+  "material: \\\"/builtins/fonts/label.material\\\"\\n"
+  "\"\n"
+  "  position {\n"
+  "    x: 32.0\n"
+  "    y: 11.0\n"
+  "  }\n"
+  "}\n"
+  ""
+  position {
+    y: -8.0
   }
 }

--- a/examples/lowrezjam/lowrezjam.script
+++ b/examples/lowrezjam/lowrezjam.script
@@ -16,6 +16,8 @@ function init(self)
 	go.animate("logo", "euler.z", go.PLAYBACK_LOOP_FORWARD, 360, go.EASING_LINEAR, 5)
 	particlefx.play("stars#stars")
 	self.actions = {}
+
+	label.set_text("/scale#label", "SCALE:" .. window.get_display_scale())
 end
 
 function update(self, dt)

--- a/game.project
+++ b/game.project
@@ -39,3 +39,9 @@ subpixels = 1
 [library]
 include_dirs = lowrez
 
+[native_extension]
+app_manifest = /lowrez/test.appmanifest
+
+[html5]
+scale_mode = downscale_fit
+

--- a/lowrez/materials/lowrez/lowrez.fp
+++ b/lowrez/materials/lowrez/lowrez.fp
@@ -1,15 +1,22 @@
-varying mediump vec4 var_position;
-varying mediump vec3 var_normal;
-varying mediump vec2 var_texcoord0;
+#version 140
+
+in highp vec4          var_position;
+in mediump vec3        var_normal;
+in mediump vec2        var_texcoord0;
+
+out vec4               out_fragColor;
 
 uniform lowp sampler2D DIFFUSE_TEXTURE;
-uniform lowp vec4 tint;
+
+uniform fs_uniforms
+{
+    mediump vec4 tint;
+};
 
 void main()
 {
     // Pre-multiply alpha since all runtime textures already are
     vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
-    vec4 color = texture2D(DIFFUSE_TEXTURE, var_texcoord0.xy) * tint_pm;
-    gl_FragColor = vec4(color.rgb,1.0);
+    vec4 color = texture(DIFFUSE_TEXTURE, var_texcoord0.xy) * tint_pm;
+    out_fragColor = vec4(color.rgb, 1.0);
 }
-

--- a/lowrez/materials/lowrez/lowrez.vp
+++ b/lowrez/materials/lowrez/lowrez.vp
@@ -1,16 +1,20 @@
+#version 140
 
 // positions are in world space
-attribute mediump vec4 position;
-attribute mediump vec2 texcoord0;
-attribute mediump vec3 normal;
+in highp vec4    position;
+in mediump vec2  texcoord0;
+in mediump vec3  normal;
 
-uniform mediump mat4 mtx_view;
-uniform mediump mat4 mtx_proj;
-uniform mediump mat4 mtx_normal;
+out highp vec4   var_position;
+out mediump vec3 var_normal;
+out mediump vec2 var_texcoord0;
 
-varying mediump vec4 var_position;
-varying mediump vec3 var_normal;
-varying mediump vec2 var_texcoord0;
+uniform vs_uniforms
+{
+    uniform mediump mat4 mtx_view;
+    uniform mediump mat4 mtx_proj;
+    uniform mediump mat4 mtx_normal;
+};
 
 void main()
 {
@@ -20,4 +24,3 @@ void main()
     var_normal = normalize((mtx_normal * vec4(normal, 0.0)).xyz);
     gl_Position = mtx_proj * p;
 }
-

--- a/lowrez/materials/sps/sps.fp
+++ b/lowrez/materials/sps/sps.fp
@@ -1,13 +1,22 @@
+#version 140
+
 // https://gist.github.com/Beefster09/7264303ee4b4b2086f372f1e70e8eddd
 // https://www.reddit.com/r/gamedev/comments/9k7xdo/fragment_shader_gist_for_smooth_pixel_scaling/
-varying mediump vec2 var_texcoord0;
+in mediump vec2        var_texcoord0;
+
+out vec4               out_fragColor;
 
 uniform lowp sampler2D DIFFUSE_TEXTURE;
-uniform lowp vec4 tint;
-uniform lowp vec4 sharpness;
-uniform lowp vec4 texture_size;
 
-float sharpen(float pix_coord) {
+uniform fs_uniforms
+{
+    lowp vec4 tint;
+    lowp vec4 sharpness;
+    lowp vec4 texture_size;
+};
+
+float sharpen(float pix_coord)
+{
     float norm = (fract(pix_coord) - 0.5) * 2.0;
     float norm2 = norm * norm;
     return floor(pix_coord) + norm * pow(norm2, sharpness.x) / 2.0 + 0.5;
@@ -21,11 +30,8 @@ void main()
 
     // Pre-multiply alpha since all runtime textures already are
     lowp vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
-    gl_FragColor = texture2D(DIFFUSE_TEXTURE, vec2(
-        sharpen(var_texcoord0.x * vres.x) / vres.x,
-        sharpen(var_texcoord0.y * vres.y) / vres.y
-    )) * tint_pm;
-    //gl_FragColor = texture2D(DIFFUSE_TEXTURE, var_texcoord0.xy) * tint_pm;
+    out_fragColor = texture(DIFFUSE_TEXTURE, vec2(sharpen(var_texcoord0.x * vres.x) / vres.x, sharpen(var_texcoord0.y * vres.y) / vres.y)) * tint_pm;
+    // gl_FragColor = texture2D(DIFFUSE_TEXTURE, var_texcoord0.xy) * tint_pm;
 
     // To visualize how this makes the grid:
     // gl_FragColor = vec4(

--- a/lowrez/render/coords.lua
+++ b/lowrez/render/coords.lua
@@ -1,4 +1,3 @@
-
 -- A module for converting mouse coordinates to GUI coordinates for checking collision with GUI nodes.
 
 local M = {}
@@ -11,8 +10,9 @@ M.game_width = 64
 M.game_height = 64
 M.scale_snap = true
 
-local function get_zoom()
-	local zoom = math.min(M.window_width / M.game_width, M.window_height / M.game_height)
+
+function M.get_zoom()
+	local zoom = math.min(M.window_width / M.game_width, M.window_height / M.game_height) / window.get_display_scale() -- <- TODO: Test this on actual device
 	if M.scale_snap then
 		zoom = math.max(1, math.floor(zoom))
 	end
@@ -21,7 +21,7 @@ end
 
 local function get_offset(zoom)
 	local w, h = M.game_width * zoom, M.game_height * zoom
-	return (M.window_width - w)/2, (M.window_height - h)/2
+	return (M.window_width - w) / 2, (M.window_height - h) / 2
 end
 
 function M.action_to_screen(ax, ay)
@@ -29,6 +29,7 @@ function M.action_to_screen(ax, ay)
 	local sy = (ay / proj_h) * M.window_height
 	return sx, sy
 end
+
 local action_to_screen = M.action_to_screen
 
 function M.screen_to_action(sx, sy)
@@ -36,19 +37,20 @@ function M.screen_to_action(sx, sy)
 	local ay = sy * proj_h / M.window_height
 	return ax, ay
 end
+
 local screen_to_action = M.screen_to_action
 
 function M.action_to_gui_pick(ax, ay)
-	local sx, sy = action_to_screen(ax, ay) -- It's way less confusing to work in real screen coords.
+	local sx, sy = action_to_screen(ax, ay)                                        -- It's way less confusing to work in real screen coords.
 
 	local action_width, action_height = screen_to_action(M.game_width, M.game_height) -- Bottom left of gui is always at 0, 0.
-	local scalex, scaley = action_width/M.game_width, action_height/M.game_height
+	local scalex, scaley = action_width / M.game_width, action_height / M.game_height
 
-	local zoom = get_zoom()
+	local zoom = M.get_zoom()
 	local ox, oy = get_offset(zoom)
 
-	local x = (sx - ox)/zoom -- Zero to `width` inside canvas area.
-	local y = (sy - oy)/zoom -- Zero to `height` inside canvas area.
+	local x = (sx - ox) / zoom -- Zero to `width` inside canvas area.
+	local y = (sy - oy) / zoom -- Zero to `height` inside canvas area.
 	x, y = x * scalex, y * scaley
 
 	return x, y -- NOTE: Not rounded to even pixels.

--- a/lowrez/render/lowrez.render_script
+++ b/lowrez/render/lowrez.render_script
@@ -1,181 +1,225 @@
-local CLEAR_COLOR = hash("clear_color")
-local SET_VIEW_PROJECTION = hash("set_view_projection")
+local coords               = require "lowrez.render.coords"
+
+local CLEAR_COLOR          = hash("clear_color")
+local SET_VIEW_PROJECTION  = hash("set_view_projection")
 local SET_UPSCALE_MATERIAL = hash("set_upscale_material")
-local SET_SCALE_SNAP = hash("set_scale_snap")
-local TOGGLE_SCALE_SNAP = hash("toggle_scale_snap")
-local SET_SIZE = hash("set_size")
+local SET_SCALE_SNAP       = hash("set_scale_snap")
+local TOGGLE_SCALE_SNAP    = hash("toggle_scale_snap")
+local SET_SIZE             = hash("set_size")
+local IDENTITY             = vmath.matrix4()
 
-local IDENTITY = vmath.matrix4()
-
-local coords = require "lowrez.render.coords"
-
+------------------------
+-- setup
+------------------------
 local function setup(self, width, height)
-	self.width = width
-	self.height = height
+	self.width             = width
+	self.height            = height
 	self.lowrez_projection = vmath.matrix4_orthographic(0, width, 0, height, -1, 1)
-	coords.game_width, coords.game_height = width, height
+
+	coords.game_width      = width
+	coords.game_height     = height
 
 	-- render target buffer parameters
-	local color_params = {
-		format = render.FORMAT_RGBA,
-		width = width,
-		height = height,
-		min_filter = render.FILTER_NEAREST,
-		mag_filter = render.FILTER_NEAREST,
-		u_wrap = render.WRAP_CLAMP_TO_EDGE,
-		v_wrap = render.WRAP_CLAMP_TO_EDGE
+	local color_params     = {
+		format     = graphics.TEXTURE_FORMAT_RGBA,
+		width      = width,
+		height     = height,
+		min_filter = graphics.TEXTURE_FILTER_NEAREST,
+		mag_filter = graphics.TEXTURE_FILTER_NEAREST,
+		u_wrap     = graphics.TEXTURE_WRAP_CLAMP_TO_EDGE,
+		v_wrap     = graphics.TEXTURE_WRAP_CLAMP_TO_EDGE
 	}
-	local depth_params = {
-		format = render.FORMAT_DEPTH,
-		width = width,
+	local depth_params     = {
+		format = graphics.TEXTURE_FORMAT_DEPTH,
+		width  = width,
 		height = height,
-		u_wrap = render.WRAP_CLAMP_TO_EDGE,
-		v_wrap = render.WRAP_CLAMP_TO_EDGE
+		u_wrap = graphics.TEXTURE_WRAP_CLAMP_TO_EDGE,
+		v_wrap = graphics.TEXTURE_WRAP_CLAMP_TO_EDGE
 	}
-	local stencil_params = {
-		format = render.FORMAT_STENCIL,
-		width = width,
+	local stencil_params   = {
+		format = graphics.TEXTURE_FORMAT_STENCIL,
+		width  = width,
 		height = height,
-		u_wrap = render.WRAP_CLAMP_TO_EDGE,
-		v_wrap = render.WRAP_CLAMP_TO_EDGE
+		u_wrap = graphics.TEXTURE_WRAP_CLAMP_TO_EDGE,
+		v_wrap = graphics.TEXTURE_WRAP_CLAMP_TO_EDGE
 	}
+
 	if self.rt then
 		render.delete_render_target(self.rt)
 	end
+
 	self.rt = render.render_target("lowrez", {
-		[render.BUFFER_COLOR_BIT] = color_params,
-		[render.BUFFER_DEPTH_BIT] = depth_params,
-		[render.BUFFER_STENCIL_BIT] = stencil_params
+		[graphics.BUFFER_TYPE_COLOR0_BIT]  = color_params,
+		[graphics.BUFFER_TYPE_DEPTH_BIT]   = depth_params,
+		[graphics.BUFFER_TYPE_STENCIL_BIT] = stencil_params
 	})
+
+	--constants
+	self.constants = render.constant_buffer()
+	self.constants.sharpness = vmath.vector4(9.9, 1.0, 1.0, 1.0)
+	self.constants.texture_size = vmath.vector4(self.width, self.height, 1.0, 1.0)
+
+	-- draw options
+	self.draw_options = {
+		frustum = vmath.matrix4(),
+		constants = self.constants
+	}
 end
 
+------------------------
+-- init
+------------------------
 function init(self)
-	self.tile_pred = render.predicate({"tile"})
-	self.gui_pred = render.predicate({"gui"})
-	self.text_pred = render.predicate({"text"})
-	self.particle_pred = render.predicate({"particle"})
-	self.lowrez_pred = render.predicate({"lowrez"})
-	self.controls_pred = render.predicate({"controls"})
+	-- predicates
+	self.tile_pred     = render.predicate({ "tile" })
+	self.gui_pred      = render.predicate({ "gui" })
+	self.text_pred     = render.predicate({ "text" })
+	self.particle_pred = render.predicate({ "particle" })
+	self.lowrez_pred   = render.predicate({ "lowrez" })
+	self.controls_pred = render.predicate({ "controls" })
 
-	self.view = IDENTITY
+	self.view          = IDENTITY
 
+	-- Lowrez Setup
 	setup(self, 64, 64)
 
-	local clear_color = vmath.vector4(0, 0, 0, 0)
-	clear_color.x = sys.get_config("render.clear_color_red", 0)
-	clear_color.y = sys.get_config("render.clear_color_green", 0)
-	clear_color.z = sys.get_config("render.clear_color_blue", 0)
-	clear_color.w = sys.get_config("render.clear_color_alpha", 0)
-	self.clear_buffers = {
-		[render.BUFFER_COLOR_BIT] = clear_color,
-		[render.BUFFER_DEPTH_BIT] = 1,
-		[render.BUFFER_STENCIL_BIT] = 0
+	-- Clear Buffer
+	local clear_color     = vmath.vector4(0, 0, 0, 0)
+	clear_color.x         = sys.get_config_number("render.clear_color_red", 0)
+	clear_color.y         = sys.get_config_number("render.clear_color_green", 0)
+	clear_color.z         = sys.get_config_number("render.clear_color_blue", 0)
+	clear_color.w         = sys.get_config_number("render.clear_color_alpha", 0)
+
+	self.clear_buffers    = {
+		[graphics.BUFFER_TYPE_COLOR0_BIT]  = clear_color,
+		[graphics.BUFFER_TYPE_DEPTH_BIT]   = 1,
+		[graphics.BUFFER_TYPE_STENCIL_BIT] = 0
 	}
 
+	-- Upscale
 	self.upscale_material = hash("lowrez")
-	self.scale_snap = true
-	coords.scale_snap = true
-	local window_width = render.get_window_width()
-	local window_height = render.get_window_height()
-	coords.window_width, coords.window_height = window_width, window_height
+	self.scale_snap       = true
+	coords.scale_snap     = true
+
+	coords.window_width   = render.get_window_width()
+	coords.window_height  = render.get_window_height()
 end
 
-
-local function clear(self, w, h)
-	-- clear
+------------------------
+-- clear
+------------------------
+local function clear(self)
 	render.set_view(IDENTITY)
-	render.set_projection(vmath.matrix4_orthographic(0, w, 0, h, -1, 1))
+	render.set_projection(vmath.matrix4_orthographic(0, coords.window_width, 0, coords.window_height, -1, 1))
 	render.set_depth_mask(true)
 	render.set_stencil_mask(0xff)
 	render.clear(self.clear_buffers)
 end
 
-
+------------------------
+-- draw_game
+-- (sprites, tiles, pfx etc)
+------------------------
 local function draw_game(self)
-	clear(self, render.get_window_width(), render.get_window_height())
-	
+	clear(self)
+
 	render.set_viewport(0, 0, self.width, self.height)
 
-	-- draw world (sprites, tiles, pfx etc)
 	render.set_depth_mask(false)
-	render.disable_state(render.STATE_DEPTH_TEST)
-	render.disable_state(render.STATE_STENCIL_TEST)
-	render.disable_state(render.STATE_CULL_FACE)
-	render.enable_state(render.STATE_BLEND)
-	render.set_blend_func(render.BLEND_SRC_ALPHA, render.BLEND_ONE_MINUS_SRC_ALPHA)
+	render.disable_state(graphics.STATE_DEPTH_TEST)
+	render.disable_state(graphics.STATE_STENCIL_TEST)
+	render.disable_state(graphics.STATE_CULL_FACE)
+
+	render.enable_state(graphics.STATE_BLEND)
+	render.set_blend_func(graphics.BLEND_FACTOR_SRC_ALPHA, graphics.BLEND_FACTOR_ONE_MINUS_SRC_ALPHA)
+
 	render.set_view(self.view)
 	render.set_projection(self.lowrez_projection)
-	render.draw(self.tile_pred)
-	render.draw(self.particle_pred)
+
+	self.draw_options.frustum = self.lowrez_projection * self.view
+
+	render.draw(self.tile_pred, self.draw_options)
+	render.draw(self.particle_pred, self.draw_options)
 	render.draw_debug3d()
-	
+
+	------------------------
 	-- draw screen space gui
-	render.set_view(vmath.matrix4())
+	------------------------
+	render.set_view(IDENTITY)
 	render.set_projection(self.lowrez_projection)
-	render.enable_state(render.STATE_STENCIL_TEST)
-	render.draw(self.gui_pred)
-	render.draw(self.text_pred)
-	render.disable_state(render.STATE_STENCIL_TEST)
+
+	self.draw_options.frustum = self.lowrez_projection * IDENTITY
+
+	render.enable_state(graphics.STATE_STENCIL_TEST)
+	render.draw(self.gui_pred, self.draw_options)
+	render.draw(self.text_pred, self.draw_options)
+	render.disable_state(graphics.STATE_STENCIL_TEST)
 end
 
-
+------------------------
+-- draw_upscaled
+------------------------
 local function draw_upscaled(self)
-	-- calculate zoom
-	local window_width = render.get_window_width()
-	local window_height = render.get_window_height()
-	local zoom = math.min(window_width / self.width, window_height / self.height)
-	if self.scale_snap then zoom = math.max(1, math.floor(zoom)) end
-
-	-- positioning
-	local width = self.width * zoom
-	local height = self.height * zoom
-	local offsetx = (window_width - width) / 2
-	local offsety = (window_height - height) / 2
+	-- zoom and positioning
+	local zoom    = coords.get_zoom()
+	local width   = self.width * zoom
+	local height  = self.height * zoom
+	local offsetx = (coords.window_width - width) / 2
+	local offsety = (coords.window_height - height) / 2
 
 	-- draw!
 	render.set_viewport(offsetx, offsety, width, height)
 	render.set_view(IDENTITY)
 	render.set_projection(IDENTITY)
-	render.enable_texture(0, self.rt, render.BUFFER_COLOR_BIT)
-	local constants = render.constant_buffer()
-	if self.upscale_material == hash("sps") then
-		constants.sharpness = vmath.vector4(9.9, 1.0, 1.0, 1.0)
-		constants.texture_size = vmath.vector4(self.width, self.height, 1.0, 1.0)
-	end
+
+	render.enable_texture("DIFFUSE_TEXTURE", self.rt, graphics.BUFFER_TYPE_COLOR0_BIT)
+
+	self.draw_options.constants.texture_size.x = self.width
+	self.draw_options.constants.texture_size.y = self.height
+
 	render.enable_material(self.upscale_material)
-	render.draw(self.lowrez_pred, { constants = constants} )
+	render.draw(self.lowrez_pred, self.draw_options)
 	render.disable_material()
-	render.disable_texture(0, self.rt)
+	render.disable_texture("DIFFUSE_TEXTURE")
 end
 
-
+------------------------
+-- draw_controls
+------------------------
 local function draw_controls(self)
-	render.set_viewport(0, 0, render.get_window_width(), render.get_window_height())
+	render.set_viewport(0, 0, coords.window_width, coords.window_height)
 	render.set_view(IDENTITY)
-	render.set_projection(vmath.matrix4_orthographic(0, render.get_window_width(), 0, render.get_window_height(), -1, 1))
+	render.set_projection(vmath.matrix4_orthographic(0, coords.window_width, 0, coords.window_height, -1, 1))
 
-	render.enable_state(render.STATE_STENCIL_TEST)
+	render.enable_state(graphics.STATE_STENCIL_TEST)
 	render.draw(self.controls_pred)
 	--render.draw(self.text_pred)
-	render.disable_state(render.STATE_STENCIL_TEST)
-	render.disable_state(render.STATE_BLEND)
+	render.disable_state(graphics.STATE_STENCIL_TEST)
+	render.disable_state(graphics.STATE_BLEND)
 end
 
+------------------------
+-- update
+------------------------
 function update(self)
-	local window_width = render.get_window_width()
-	local window_height = render.get_window_height()
-	coords.window_width, coords.window_height = window_width, window_height
-	clear(self, window_width, window_height)
-	render.enable_render_target(self.rt)
+	coords.window_width  = render.get_window_width()
+	coords.window_height = render.get_window_height()
+
+	clear(self)
+
+	-- draw game to render target
+	render.set_render_target(self.rt)
 	draw_game(self)
-	render.disable_render_target(self.rt)
+
+	-- draw to screen
+	render.set_render_target(render.RENDER_TARGET_DEFAULT)
 	draw_upscaled(self)
 	draw_controls(self)
 end
 
 function on_message(self, message_id, message)
 	if message_id == CLEAR_COLOR then
-		self.clear_buffers[render.BUFFER_COLOR_BIT] = message.color
+		self.clear_buffers[graphics.BUFFER_TYPE_COLOR0_BIT] = message.color
 	elseif message_id == SET_VIEW_PROJECTION then
 		self.view = message.view
 	elseif message_id == SET_UPSCALE_MATERIAL then

--- a/lowrez/test.appmanifest
+++ b/lowrez/test.appmanifest
@@ -1,0 +1,105 @@
+platforms:
+  armv7-ios:
+    context:
+      excludeLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      frameworks: []
+      linkFlags: []
+  arm64-ios:
+    context:
+      excludeLibs: [graphics]
+      excludeSymbols: [GraphicsAdapterOpenGL]
+      symbols: [GraphicsAdapterVulkan]
+      libs: [graphics_vulkan, MoltenVK]
+      frameworks: [Metal, IOSurface, QuartzCore]
+      linkFlags: []
+  x86_64-ios:
+    context:
+      excludeLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      frameworks: []
+      linkFlags: []
+  armv7-android:
+    context:
+      excludeLibs: [graphics]
+      excludeJars: []
+      excludeSymbols: [GraphicsAdapterOpenGL]
+      symbols: [GraphicsAdapterVulkan]
+      libs: [graphics_vulkan]
+      linkFlags: []
+      jetifier: true
+  arm64-android:
+    context:
+      excludeLibs: [graphics]
+      excludeJars: []
+      excludeSymbols: [GraphicsAdapterOpenGL]
+      symbols: [GraphicsAdapterVulkan]
+      libs: [graphics_vulkan]
+      linkFlags: []
+      jetifier: true
+  arm64-osx:
+    context:
+      excludeLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      frameworks: []
+      linkFlags: []
+  x86_64-osx:
+    context:
+      excludeLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      frameworks: []
+      linkFlags: []
+  x86_64-linux:
+    context:
+      excludeLibs: [graphics]
+      excludeSymbols: [GraphicsAdapterOpenGL]
+      symbols: [GraphicsAdapterVulkan]
+      libs: [platform_vulkan, graphics_vulkan, X11-xcb]
+      dynamicLibs: [vulkan]
+      linkFlags: []
+  arm64-linux:
+    context:
+      excludeLibs: [graphics]
+      excludeSymbols: [GraphicsAdapterOpenGLES]
+      symbols: [GraphicsAdapterVulkan]
+      libs: [platform_vulkan, graphics_vulkan, X11-xcb]
+      dynamicLibs: [vulkan]
+      linkFlags: []
+  x86-win32:
+    context:
+      excludeLibs: [libplatform, libgraphics]
+      excludeSymbols: [GraphicsAdapterOpenGL]
+      symbols: [GraphicsAdapterVulkan]
+      libs: [libplatform_vulkan.lib, libgraphics_vulkan.lib, vulkan-1.lib]
+      linkFlags: []
+  x86_64-win32:
+    context:
+      excludeLibs: [libplatform, libgraphics]
+      excludeSymbols: [GraphicsAdapterOpenGL]
+      symbols: [GraphicsAdapterVulkan]
+      libs: [libplatform_vulkan.lib, libgraphics_vulkan.lib, vulkan-1.lib]
+      linkFlags: []
+  js-web:
+    context:
+      excludeLibs: []
+      excludeJsLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      linkFlags: []
+  wasm-web:
+    context:
+      excludeLibs: []
+      excludeJsLibs: []
+      excludeSymbols: []
+      symbols: []
+      libs: []
+      linkFlags: []


### PR DESCRIPTION
I only meant to update the shaders, but… :)
Merge if you like!

### Shaders
- `lowres` and `sps` shaders updated for the new pipeline.

### `lowrezjam.script`
- Display scale label added

### `game.project`
- `test.appmanifest` added for testing shaders with both OpenGL and Vulkan

### `coords.lua`
- `get_zoom()` made public to be used in the render script instead of calculating it separately.
- `window.get_display_scale()` added to zoom calculation.   *Note: I don’t have a Retina device, this should be tested.*

### `lowrez.render_script`
- Refactor
- Replaced deprecated render and sys.get_config functions to new ones
- Updated to use the new graphics API
- Removed unnecessary calls to `render.get_window_width()` and `render.get_window_height()`
- Frustum culling added to all draw calls